### PR TITLE
Add chronological tour itineraries display to booking details

### DIFF
--- a/app/Filament/Resources/Bookings/BookingResource.php
+++ b/app/Filament/Resources/Bookings/BookingResource.php
@@ -5,6 +5,8 @@ namespace App\Filament\Resources\Bookings;
 use App\Filament\Resources\Bookings\Pages\CreateBooking;
 use App\Filament\Resources\Bookings\Pages\EditBooking;
 use App\Filament\Resources\Bookings\Pages\ListBookings;
+use App\Filament\Resources\Bookings\Pages\ViewBooking;
+use App\Filament\Resources\Bookings\RelationManagers\ItinerariesRelationManager;
 use App\Filament\Resources\Bookings\Schemas\BookingForm;
 use App\Filament\Resources\Bookings\Tables\BookingsTable;
 use App\Models\Booking;
@@ -13,6 +15,7 @@ use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
+use UnitEnum;
 
 class BookingResource extends Resource
 {
@@ -20,7 +23,17 @@ class BookingResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
 
-    protected static ?string $recordTitleAttribute = 'Booking';
+    protected static ?string $navigationLabel = 'Bookings';
+
+    protected static ?string $modelLabel = 'Booking';
+
+    protected static ?string $pluralModelLabel = 'Bookings';
+
+    protected static ?string $recordTitleAttribute = 'id';
+
+    protected static ?int $navigationSort = 1;
+
+    protected static string|UnitEnum|null $navigationGroup = 'Tour Management';
 
     public static function form(Schema $schema): Schema
     {
@@ -35,7 +48,7 @@ class BookingResource extends Resource
     public static function getRelations(): array
     {
         return [
-            //
+            ItinerariesRelationManager::class,
         ];
     }
 
@@ -44,6 +57,7 @@ class BookingResource extends Resource
         return [
             'index' => ListBookings::route('/'),
             'create' => CreateBooking::route('/create'),
+            'view' => ViewBooking::route('/{record}'),
             'edit' => EditBooking::route('/{record}/edit'),
         ];
     }

--- a/app/Filament/Resources/Bookings/Pages/ViewBooking.php
+++ b/app/Filament/Resources/Bookings/Pages/ViewBooking.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Bookings\Pages;
+
+use App\Filament\Resources\Bookings\BookingResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewBooking extends ViewRecord
+{
+    protected static string $resource = BookingResource::class;
+}

--- a/app/Filament/Resources/Bookings/RelationManagers/ItinerariesRelationManager.php
+++ b/app/Filament/Resources/Bookings/RelationManagers/ItinerariesRelationManager.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Filament\Resources\Bookings\RelationManagers;
+
+use Filament\Actions\ViewAction;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class ItinerariesRelationManager extends RelationManager
+{
+    protected static string $relationship = 'itineraries';
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('title')
+            ->columns([
+                TextColumn::make('day_number')
+                    ->label('Day')
+                    ->sortable()
+                    ->badge()
+                    ->color('info'),
+
+                TextColumn::make('time_of_day')
+                    ->label('Time')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'morning' => 'success',
+                        'afternoon' => 'warning',
+                        'evening' => 'danger',
+                        'full_day' => 'info',
+                        default => 'gray',
+                    })
+                    ->sortable(),
+
+                TextColumn::make('title')
+                    ->searchable()
+                    ->sortable()
+                    ->limit(40),
+
+                TextColumn::make('location')
+                    ->searchable()
+                    ->limit(30)
+                    ->toggleable(),
+
+                TextColumn::make('description')
+                    ->limit(60)
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('time_of_day')
+                    ->options([
+                        'morning' => 'Morning',
+                        'afternoon' => 'Afternoon',
+                        'evening' => 'Evening',
+                        'full_day' => 'Full Day',
+                    ]),
+            ])
+            ->headerActions([
+                // View-only, no create action
+            ])
+            ->actions([
+                ViewAction::make(),
+            ])
+            ->bulkActions([
+                // View-only, no bulk actions
+            ])
+            ->modifyQueryUsing(function ($query) {
+                return $query->orderBy('day_number', 'asc')
+                    ->orderByRaw("CASE 
+                               WHEN time_of_day = 'morning' THEN 1
+                               WHEN time_of_day = 'afternoon' THEN 2
+                               WHEN time_of_day = 'evening' THEN 3
+                               WHEN time_of_day = 'full_day' THEN 4
+                               ELSE 5
+                           END");
+            });
+    }
+}


### PR DESCRIPTION
## Summary
- Add chronological display of tour itineraries in booking details pages
- Create view-only relation manager for better tour schedule visibility
- Implement time-based sorting and color-coded badges

## Changes Made
- **ItinerariesRelationManager**: New relation manager for viewing tour itineraries in booking details
- **ViewBooking Page**: Added dedicated view page to display itineraries in both View and Edit booking pages  
- **Time-based sorting**: Itineraries sorted by day number and time of day (morning → afternoon → evening → full_day)
- **View-only access**: Read-only interface with color-coded time badges for better UX
- **Enhanced booking details**: Both View and Edit booking pages now show chronological tour itineraries

## Test plan
- [x] Navigate to Tour Management → Bookings
- [x] Click View (eye icon) on any booking → Verify Itineraries tab shows with chronological sorting
- [x] Click Edit (pencil icon) on any booking → Verify Itineraries tab shows with same chronological sorting
- [x] Verify itineraries are sorted by day number then time of day
- [x] Verify time badges show correct colors (morning=green, afternoon=orange, evening=red, full_day=blue)
- [x] Verify view-only access (no create/edit/delete buttons)

🤖 Generated with [Claude Code](https://claude.ai/code)